### PR TITLE
Support Workspaces

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698166613,
-        "narHash": "sha256-y4rdN4flxRiROqNi1waMYIZj/Fs7L2OrszFk/1ry9vU=",
+        "lastModified": 1712180168,
+        "narHash": "sha256-sYe00cK+kKnQlVo1wUIZ5rZl9x8/r3djShUqNgfjnM4=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "b7db46f0f1751f7b1d1911f6be7daf568ad5bc65",
+        "rev": "06a9ff255c1681299a87191c2725d9d579f28b82",
         "type": "github"
       },
       "original": {
@@ -26,11 +26,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1698387704,
-        "narHash": "sha256-Ei9J3yyiaEXKIJPmTqb2f3DPsg/XNfQLYvMxRwYzsH8=",
+        "lastModified": 1712211755,
+        "narHash": "sha256-KIJA4OvXFDXEeu7wstFDCxqZEfjaPQIowpzNww48TUw=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "30701a50e292780bb1a8283f310bd456dd2d0ce5",
+        "rev": "39763c6e23a8423af316b85a74bad0cc5bc88d86",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1698134075,
-        "narHash": "sha256-foCD+nuKzfh49bIoiCBur4+Fx1nozo+4C/6k8BYk4sg=",
+        "lastModified": 1712122226,
+        "narHash": "sha256-pmgwKs8Thu1WETMqCrWUm0CkN1nmCKX3b51+EXsAZyY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8efd5d1e283604f75a808a20e6cde0ef313d07d4",
+        "rev": "08b9151ed40350725eb40b1fe96b0b86304a654b",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1698318101,
-        "narHash": "sha256-gUihHt3yPD7bVqg+k/UVHgngyaJ3DMEBchbymBMvK1E=",
+        "lastModified": 1712122226,
+        "narHash": "sha256-pmgwKs8Thu1WETMqCrWUm0CkN1nmCKX3b51+EXsAZyY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "63678e9f3d3afecfeafa0acead6239cdb447574c",
+        "rev": "08b9151ed40350725eb40b1fe96b0b86304a654b",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1698337999,
-        "narHash": "sha256-UHk2hKVUN+t2v5x3u6un7FGA9Xlzs6gArs7Hi/FJXJs=",
+        "lastModified": 1712156296,
+        "narHash": "sha256-St7ZQrkrr5lmQX9wC1ZJAFxL8W7alswnyZk9d1se3Us=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "46c395d57090f2ec5784d7fcad57a130911e44f7",
+        "rev": "8e581ac348e223488622f4d3003cb2bd412bf27e",
         "type": "github"
       },
       "original": {
@@ -132,11 +132,11 @@
     "workers-rs": {
       "flake": false,
       "locked": {
-        "lastModified": 1696192204,
-        "narHash": "sha256-+J+H7lQMvVzVFRGlw2I4PWCGUk4NYAvKuPumMyrwI1A=",
+        "lastModified": 1712083113,
+        "narHash": "sha256-k8F8iX7kS+Jfz22ge84P7DoL1PAM+uuB/5uhjvzvY5w=",
         "owner": "cloudflare",
         "repo": "workers-rs",
-        "rev": "1d307145d9114d3241932ed2965fb1c65e6a67a9",
+        "rev": "c1805b65285e4d0fa16c1496ea7d7052b44b4655",
         "type": "github"
       },
       "original": {

--- a/src/wasm-pack.nix
+++ b/src/wasm-pack.nix
@@ -36,14 +36,14 @@ in
         or ''
           HOME=$(mktemp -d)
 
-          wasm-pack build \
+          wasm-pack build ${if args.workspace then args.pname else "./"} \
             --no-typescript \
             --target bundler \
             --out-dir build \
             --out-name index \
             --release
 
-          substituteInPlace build/index_bg.js \
+          substituteInPlace ${if args.workspace then args.pname else "."}/build/index_bg.js \
             --replace "${wasmImport}" "${wasmImportReplacement}"
         '';
 
@@ -54,9 +54,9 @@ in
         or ''
           mkdir $out
 
-          mv build/index_bg.js $out
-          mv build/index_bg.wasm $out/index.wasm
+          mv ${if args.workspace then args.pname else "."}/build/index_bg.js $out
+          mv ${if args.workspace then args.pname else "."}/build/index_bg.wasm $out/index.wasm
 
-          [ -f build/snippets ] && mv build/snippets $out
+          [ -f build/snippets ] && mv ${if args.workspace then args.pname else "."}/build/snippets $out
         '';
     })


### PR DESCRIPTION
Bit of a *rudamentary* approach to this, but was done to unblock my work breaking up one of my monolithic workers into a handful of much smaller units (https://git.gmem.ca/arch/gabrielsimmer.com). 

Needs to be manually enabled with

```
            web = freight.lib.${system}.mkWorker {
              pname = "web";
              version = "0.1.0";

              workspace = true; # <--
              src = ./.;
            };
```

This is because wasm-pack is a bit naive in its building approach, so specifying the workspace to cd into it neccessary. 